### PR TITLE
Specify Runner OS Version in Workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-package:
     name: Build Package
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.7

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   check-package:
     name: Check Package
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.7
@@ -42,7 +42,7 @@ jobs:
 
   test-package:
     name: Test Package
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.7


### PR DESCRIPTION
This pull request resolves #82 by manually specifying the runner OS version to be used in workflows, replacing the default latest version.