### PR TITLE
Remove Upload Artifact Steps in CI Workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,8 +33,3 @@ jobs:
 
       - name: Build Package
         run: poetry build
-
-      - name: Upload Package
-        uses: actions/upload-artifact@v4.6.2
-        with:
-          path: dist/*


### PR DESCRIPTION
This pull request resolves #162 by removing the upload artifact steps from the `build` workflow. This change also modify the `build` workflow to build the package with a default tarball name.